### PR TITLE
change shebang to python 3

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Django's command-line utility for administrative tasks."""
 import os
 import sys


### PR DESCRIPTION
change shebang to python 3 to suppport ansible python interpreter when run django_migrate